### PR TITLE
fix courseSession creation logic

### DIFF
--- a/services/courseSession.ts
+++ b/services/courseSession.ts
@@ -9,13 +9,11 @@ export async function getOrCreateCourseSession(
     start: Date,
 ): Promise<GetOrCreateCourseSessionResult> {
     try {
-        const courseSessions : CourseSession[] = await prisma.courseSession.findMany({
-            where: { courseId, startTime: start },
+        const courseSession = await prisma.courseSession.findFirst({
+            where: { courseId, startTime: start, endTime: null },
         });
-        
-        for (const session of courseSessions){
-            if (session.endTime == null) return session;
-        }
+
+        if(courseSession) return courseSession;
 
         return await prisma.courseSession.create({
             data: {

--- a/services/courseSession.ts
+++ b/services/courseSession.ts
@@ -9,10 +9,13 @@ export async function getOrCreateCourseSession(
     start: Date,
 ): Promise<GetOrCreateCourseSessionResult> {
     try {
-        const courseSession = await prisma.courseSession.findFirst({
+        const courseSessions : CourseSession[] = await prisma.courseSession.findMany({
             where: { courseId, startTime: start },
         });
-        if (courseSession) return courseSession;
+        
+        for (const session of courseSessions){
+            if (session.endTime == null) return session;
+        }
 
         return await prisma.courseSession.create({
             data: {


### PR DESCRIPTION
## Pull Request Template

**Referenced Issue:** N/A

**Reviewers (if applicable):** N/A

> [!NOTE]
> Inform your reviewers using Slack on PRs in addition to tagging them on the PR.

**Description of changes**
changed getOrCreateCourseSession() in services to create a new course session if there is no course session for that day or if all existing course sessions have an end time specified.

> [!IMPORTANT]
> Run a local build first to ensure everything is working
