### PR TITLE
changed how totalVotes is defined

### DIFF
--- a/app/dashboard/course/[courseId]/start-session/page.tsx
+++ b/app/dashboard/course/[courseId]/start-session/page.tsx
@@ -181,7 +181,7 @@ export default function StartSession() {
     }
 
     const activeQuestion = questions ? questions.find((q) => q.id === activeQuestionId) : null;
-    const totalVotes = chartData.reduce((sum, item) => sum + item.Votes, 0);
+    const totalVotes = questionData ? new Set(questionData.responses.map((resp) => resp.userId)).size : 0;
 
     return (
         <div className="flex flex-col items-center p-4">

--- a/app/dashboard/course/[courseId]/start-session/page.tsx
+++ b/app/dashboard/course/[courseId]/start-session/page.tsx
@@ -181,6 +181,8 @@ export default function StartSession() {
     }
 
     const activeQuestion = questions ? questions.find((q) => q.id === activeQuestionId) : null;
+
+    // totalVotes is total number of unique users that responded to the question
     const totalVotes = questionData ? new Set(questionData.responses.map((resp) => resp.userId)).size : 0;
 
     return (

--- a/models/CourseSession.ts
+++ b/models/CourseSession.ts
@@ -19,5 +19,5 @@ export interface WildcardPayload {
 }
 export interface QuestionData {
     options: { id: number; text: string }[];
-    responses: { optionId: number }[];
+    responses: { optionId: number , userId: string}[];
 }


### PR DESCRIPTION
totalVotes now contains the number of unique votes. Unique as in we utilize the unique id of a student (userId) to not count their vote twice.

**Referenced Issue:** #35  

**Description of changes**

Changed the way totalVotes is defined in app\dashboard\course\[courseId]\start-session\page.tsx such that we only care about unique votes and not the sum of votes for all options regardless of them being done by the same user or not. Also uppdated models\CourseSession.ts so that I could obtain the userId string of users in order to make this logic work.

One user selects one option and it works as it shows 100%.
![image](https://github.com/user-attachments/assets/cad302b6-bfc9-4348-979c-6f1eea474d64)

One user selects two options and it works as it shows 100%. Previously this would have been 50% for each option.
![image](https://github.com/user-attachments/assets/b152bafc-ffc6-48b3-896a-ad40f30fc12a)
![image](https://github.com/user-attachments/assets/7d3ebcad-8696-4983-bc7e-675c817074b0)

Two users. One user selects A and B. The other user selects B.
![image](https://github.com/user-attachments/assets/54d95323-807b-42d0-a069-c29f1b58bcfd)
![image](https://github.com/user-attachments/assets/c2eff335-8f7c-4da9-b424-d773a50a0851)

Two users. One user selects A and B. The other user selects C.
![image](https://github.com/user-attachments/assets/7945758e-27a5-4946-ae17-7b6d7a345796)
![image](https://github.com/user-attachments/assets/08b4a2db-91dd-4372-8aa9-04a3237990f2)
