### PR TITLE
Design fix for options on different screen size

### DIFF
--- a/app/dashboard/course/[courseId]/start-session/page.tsx
+++ b/app/dashboard/course/[courseId]/start-session/page.tsx
@@ -30,6 +30,7 @@ import {
     getQuestionsForSession,
 } from "@/services/session";
 
+
 export default function StartSession() {
     const params = useParams();
     const router = useRouter();
@@ -183,6 +184,7 @@ export default function StartSession() {
 
     const activeQuestion = questions ? questions.find((q) => q.id === activeQuestionId) : null;
     const totalVotes = chartData.reduce((sum, item) => sum + item.Votes, 0);
+    
 
     return (
         <div className="flex flex-col items-center p-4">
@@ -213,7 +215,7 @@ export default function StartSession() {
                                     data={chartData}
                                     layout="vertical"
                                     barCategoryGap={20}
-                                    margin={{ left: 100, right: 20, top: 20, bottom: 20 }}
+                                    margin={{ left: 100, right: 20, top: 0, bottom: 0 }}
                                 >
                                     <XAxis type="number" domain={[0, totalVotes]} hide />
                                     <YAxis
@@ -222,7 +224,7 @@ export default function StartSession() {
                                         tick={<LetteredYAxisTick />}
                                         tickLine={false}
                                         axisLine={false}
-                                        tickMargin={8}
+                                        tickMargin={9}
                                         style={{ fill: "#000" }}
                                     />
                                     <ChartTooltip

--- a/components/YAxisTick.tsx
+++ b/components/YAxisTick.tsx
@@ -12,36 +12,45 @@ export function LetteredYAxisTick({ x = 0, y = 0, payload }: EllipsisYAxisTickPr
     if (!payload) return null;
 
     const fullText = payload.value;
-    const maxChars = 15;
-    const truncated =
-        fullText.length > maxChars ? fullText.slice(0, maxChars) + " . . . " : fullText;
+    const maxChars = 10;
+    const truncated = fullText.length > maxChars ? fullText.slice(0, maxChars) : fullText;
 
     return (
         <g transform={`translate(${x},${y})`}>
-            <text textAnchor="end" fill="#000" dy={4} dx={-2} fontSize={12}>
+            <text textAnchor="end" fill="#000" dy={4} dx={-2} fontSize={14} fontWeight={"Bold"}>
                 {truncated}
             </text>
             {fullText.length > maxChars && (
-                <foreignObject x={-16.9} y={-6} width={20} height={20}>
-                    <Popover>
-                        <PopoverTrigger asChild>
-                            <button
-                                style={{
-                                    background: "none",
-                                    border: "none",
-                                    cursor: "pointer",
-                                    padding: 0,
-                                }}
-                            >
-                                <MoreHorizontal size={16} />
-                            </button>
-                        </PopoverTrigger>
-                        <PopoverContent>
-                            <div style={{ padding: "0.5rem 1rem", whiteSpace: "normal" }}>
-                                {fullText}
-                            </div>
-                        </PopoverContent>
-                    </Popover>
+                <foreignObject x={-10} y={-12} width={30} height={30}>
+                    <div
+                        style={{
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            width: "100%",
+                            height: "100%",
+                        }}
+                    >
+                        <Popover>
+                            <PopoverTrigger asChild>
+                                <button
+                                    style={{
+                                        background: "none",
+                                        border: "none",
+                                        cursor: "pointer",
+                                        padding: 0,
+                                    }}
+                                >
+                                    <MoreHorizontal size={16} />
+                                </button>
+                            </PopoverTrigger>
+                            <PopoverContent>
+                                <div style={{ padding: "0.5rem 1rem", whiteSpace: "normal" }}>
+                                    {fullText}
+                                </div>
+                            </PopoverContent>
+                        </Popover>
+                    </div>
                 </foreignObject>
             )}
         </g>


### PR DESCRIPTION
## Fix BarChart Clipping on Small Devices with Adjusted Margins

**Referenced Issue:** #27 

**Reviewers (if applicable):** @j3rrythomas 

## Summary

This PR addresses the clipping issue of the BarChart component on most screen sizes by manually adjusting the margins. Although this change resolves clipping for nearly all devices, the following devices still experience issues:

- **iPhone 12 Pro (390×844)**
- **iPhone SE (375 x 667)**
- **Samsung Galaxy S8 (360 x 740)**
- **Galaxy Z Fold 5 (344 x 882)**

## Details

- **Clipping Fixed:**  
  Manual margin adjustments have been applied to prevent the chart content from overflowing its container on small screens.

- **Squished Bar Issue:**  
  One thing I saw was that the bars still appear slightly squished on these devices. Future iterations could leverage dynamic adjustments such as onResize to potentially fix this by making custom margin for smaller screen sizes.

## Next Steps

- I think we should monitor feedback and performance on the affected devices (unlikely due to professors mostly using  > tablet devices). 
- Consider dynamic approaches (such as onResize-driven margin changes) in subsequent updates to improve the squished bar issue.

