### PR TITLE
Bug/UI update upon question edit delete add

### DIFF
--- a/app/dashboard/course/[courseId]/questionnaire/page.tsx
+++ b/app/dashboard/course/[courseId]/questionnaire/page.tsx
@@ -24,6 +24,10 @@ export default function Page() {
     const router = useRouter();
     const { toast } = useToast();
     const { hasAccess, isLoading: isAccessLoading } = useAccess({ courseId, role: "LECTURER" });
+    const [refreshCalendar, setRefreshCalendar] = useState(false);
+    const handleQuestionUpdate = () => {
+        setRefreshCalendar(prev => !prev);
+    };
 
     useEffect(() => {
         if (isAccessLoading) {
@@ -73,6 +77,7 @@ export default function Page() {
                         defaultDate={new Date(formatDateToISO(new Date()))}
                         courseId={courseId}
                         location="page"
+                        onUpdate={handleQuestionUpdate}
                     />
                     
                     {hasActiveSession ? (
@@ -89,7 +94,7 @@ export default function Page() {
                     )}
                 </div>
             </section>
-            <SlidingCalendar courseId={courseId} />
+            <SlidingCalendar courseId={courseId} refreshTrigger={refreshCalendar} />
             <AddInstructorForm />
         </div>
     );

--- a/components/AddEditQuestionForm.tsx
+++ b/components/AddEditQuestionForm.tsx
@@ -70,6 +70,7 @@ interface Props {
             choice: string;
         }[];
     };
+    onUpdate?: () => void;
 }
 
 export const AddEditQuestionForm: React.FC<Props> = ({
@@ -77,6 +78,7 @@ export const AddEditQuestionForm: React.FC<Props> = ({
     location,
     defaultDate,
     questionId,
+    onUpdate,
     prevData,
 }: Props) => {
     const form = useForm<z.infer<typeof schema>>({
@@ -112,16 +114,23 @@ export const AddEditQuestionForm: React.FC<Props> = ({
     const [loading, setLoading] = useState<boolean>(false);
 
     useEffect(() => {
-        if (!prevData) return;
-        prevData.answerChoices = prevData.answerChoices.filter(
-            (answerChoice) => answerChoice.choice !== "",
-        );
-        form.setValue("answerChoices", prevData.answerChoices);
-        prevData.correctAnswers = prevData.correctAnswers.filter(
-            (correctAnswer) => correctAnswer.answer !== "",
-        );
-        form.setValue("correctAnswers", prevData.correctAnswers);
+        if (prevData) {
+            const cleanedPrevData = {
+                ...prevData,
+                answerChoices: prevData.answerChoices.filter((c) => c.choice !== ""),
+                correctAnswers: prevData.correctAnswers.filter((a) => a.answer !== ""),
+            };
+            form.reset(cleanedPrevData);
+        } else {
+            form.reset({
+                question: "",
+                selectedQuestionType: "Multiple Choice",
+                correctAnswers: [{ answer: "" }],
+                answerChoices: [{ choice: "" }],
+            });
+        }
     }, [prevData]);
+    
 
     useEffect(() => {
         if (!defaultDate) return;
@@ -209,6 +218,9 @@ export const AddEditQuestionForm: React.FC<Props> = ({
                     setIsOpen(false);
                     setLoading(false);
                     form.reset();
+                    if (typeof onUpdate === "function") {
+                        onUpdate();
+                    }
                     return toast({
                         description: questionId
                             ? "Question updated successfully"

--- a/components/ui/SlidingCalendar.tsx
+++ b/components/ui/SlidingCalendar.tsx
@@ -41,7 +41,7 @@ function SlidingCalendar({ courseId }: Props) {
     const { toast } = useToast();
 
     useEffect(() => {
-        const currentDate = dayjs();
+        const currentDate = dayjs().startOf("day");
         setSelectedDate(currentDate);
     }, []);
 

--- a/components/ui/SlidingCalendar.tsx
+++ b/components/ui/SlidingCalendar.tsx
@@ -43,7 +43,6 @@ function SlidingCalendar({ courseId }: Props) {
     useEffect(() => {
         const currentDate = dayjs();
         setSelectedDate(currentDate);
-        fetchQuestions(currentDate.toDate());
     }, []);
 
     const fetchQuestions = async (date: Date) => {
@@ -253,6 +252,7 @@ function SlidingCalendar({ courseId }: Props) {
                                                             courseId={courseId}
                                                             location="page"
                                                             questionId={question.id}
+                                                            onUpdate={() => fetchQuestions(selectedDate.toDate())}
                                                             prevData={{
                                                                 question: question.text,
                                                                 selectedQuestionType:
@@ -298,6 +298,7 @@ function SlidingCalendar({ courseId }: Props) {
                             courseId={courseId}
                             location="calendar"
                             defaultDate={new Date(formatDateToISO(selectedDate?.toDate()))}
+                            onUpdate={() => fetchQuestions(selectedDate.toDate())}
                         />
                     </div>
                 )}

--- a/components/ui/SlidingCalendar.tsx
+++ b/components/ui/SlidingCalendar.tsx
@@ -21,9 +21,10 @@ import { formatDateToISO } from "@/lib/utils";
 
 interface Props {
     courseId: number;
+    refreshTrigger?: boolean;
 }
 
-function SlidingCalendar({ courseId }: Props) {
+function SlidingCalendar({ courseId, refreshTrigger }: Props) {
     const [startDate, setStartDate] = useState<Dayjs>(dayjs().startOf("week"));
     const [selectedDate, setSelectedDate] = useState<Dayjs>(dayjs());
     const [questions, setQuestions] = useState<
@@ -64,7 +65,7 @@ function SlidingCalendar({ courseId }: Props) {
         if (selectedDate) {
             fetchQuestions(selectedDate.toDate());
         }
-    }, [selectedDate]);
+    }, [selectedDate, refreshTrigger]);
 
     // fetch incorrect and correct options of selected question
     useEffect(() => {

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -17,7 +17,7 @@ const ToastViewport = React.forwardRef<
     <ToastPrimitives.Viewport
         ref={ref}
         className={cn(
-            "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:flex-col md:max-w-[420px]",
+            "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:flex-col md:max-w-[420px] pointer-events-none",
             className,
         )}
         {...props}


### PR DESCRIPTION
#41 

https://github.com/user-attachments/assets/650da9f2-056f-4ed1-a250-dfa2ec933423


**Description of changes**
Made change to toast.tsx in order to stop it from disabling some of the buttons. Added update logic to SlidingCalendar.tsx and AddEditQuestionForm.tsx so the UI is up to date with the addition or removal of questions. In SlidingCalendar.tsx I made the useEffect store the date in the format that is compatible to the fetchQuestions function so that upon refresh, it shows the questions of the current date without having to click on the date again. Changed some of the Edit logic in AddEditQuestionForm.tsx so that previous edit values appear when you try to edit instead of original values. Also updates UI on the Calendar when you edit.

